### PR TITLE
WDT-46: Hoàn thành chức năng lịch sử đọc truyện (frontend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# TruyenDep - Website Đọc Truyện Online
+
+Dự án website đọc truyện tranh online được xây dựng bằng React, TypeScript, và Vite. Đây là một sản phẩm học tập nhằm áp dụng các kiến thức về phát triển frontend hiện đại và quy trình làm việc nhóm chuyên nghiệp.
+
+## Quản lý dự án
+
+Dự án này được quản lý và theo dõi tiến độ bằng các công cụ:
+
+- **Jira:** Để quản lý các task, user story, và sprint.
+- **GitHub:** Để quản lý mã nguồn, review code qua Pull Request.
+- **Git Flow:** Áp dụng mô hình Git Flow rút gọn với các nhánh `main`, `develop`, và các nhánh `feature/*` cho từng tính năng hoặc thành viên.
+
+## Các tính năng chính
+
+- ✅ Giao diện trang chủ, tìm kiếm, chi tiết truyện, đọc truyện.
+- ✅ Phân loại truyện theo thể loại.
+- ✅ Giao diện responsive cho cả desktop và mobile.
+- ✅ Form đăng ký, đăng nhập.
+- ⏳ (Đang phát triển) Các tính năng cho người dùng đã đăng nhập như lưu truyện yêu thích, bình luận, đánh giá.
+- ⏳ (Đang phát triển) Trang quản trị cho admin.
+
+## Công nghệ sử dụng
+
+- **Framework:** [ReactJS](https://react.dev/)
+- **Ngôn ngữ:** [TypeScript](https://www.typescriptlang.org/)
+- **Build Tool:** [Vite](https://vitejs.dev/)
+- **Styling:** [Tailwind CSS](https://tailwindcss.com/)
+- **Routing:** [React Router DOM](https://reactrouter.com/)
+- **Icons:** [Lucide React](https://lucide.dev/)
+
+## Hướng dẫn cài đặt và chạy Project
+
+Để chạy project này ở môi trường local, bạn hãy làm theo các bước sau:
+
+**1. Clone repository về máy:**
+
+```bash
+git clone https://github.com/PhatBanhTeam/Truyendep.git
+```
+
+**2. Di chuyển vào thư mục project:**
+
+```bash
+cd Truyendep
+```
+
+**3. Cài đặt các dependencies:**
+
+```bash
+npm install
+```
+
+**4. Chạy server phát triển:**
+
+```bash
+npm run dev
+```
+
+Sau đó, mở trình duyệt và truy cập vào `http://localhost:5173` (hoặc cổng khác được hiển thị trong terminal).
+
+## Đội ngũ phát triển
+
+- **Phát** (UI/UX)
+- **Đạt** (UI/UX)
+- **Duy** (Backend)
+- **Lộc** (Product Owner / Task Manager)
+
+## Ảnh chụp màn hình
+
+|                                           Trang chủ                                           |                                              Đăng nhập                                              |                                              Đăng ký                                              |
+| :-------------------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------: |
+| ![Trang chủ](https://github.com/user-attachments/assets/414da4c6-713b-411e-81ee-f54d8b77ed61) | ![Trang Đăng nhập](https://github.com/user-attachments/assets/b4c6cb05-7a1c-4e7b-b1f5-d10ab1064d0f) | ![Trang Đăng ký](https://github.com/user-attachments/assets/ef59d9f5-824f-48b5-804f-53cf49f2ca3e) |
+|                                      **Chi tiết truyện**                                      |                                           **Đọc truyện**                                            |                                              **...**                                              |
+|                              _Chèn ảnh chi tiết truyện vào đây_                               |                                    _Chèn ảnh đọc truyện vào đây_                                    |                                               _..._                                               |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,8 @@ import { RecentPage } from "./pages/RecentPage";
 import { TopRatedPage } from "./pages/TopRatedPage";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
+import AdminDashboardPage from "./pages/AdminDashboardPage";
+import HistoryPage from "./pages/HistoryPage";
 
 function App() {
   const handleSearch = (query: string) => {
@@ -46,6 +48,11 @@ function App() {
                     <Route path="/recent" element={<RecentPage />} />
                     <Route path="/top-rated" element={<TopRatedPage />} />
                     <Route path="/genre/:slug" element={<CategoryPage />} />
+                    <Route path="/history" element={<HistoryPage />} />
+                    <Route
+                      path="/admin/dashboard"
+                      element={<AdminDashboardPage />}
+                    />
                   </Routes>
                 </main>
                 <Footer />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -8,6 +8,7 @@ import {
   Clock,
   Star,
   Filter,
+  History,
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import { api } from "../../services/api";
@@ -19,7 +20,9 @@ interface HeaderProps {
 export const Header: React.FC<HeaderProps> = ({ onSearch }) => {
   const [searchQuery, setSearchQuery] = useState("");
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const [categories, setCategories] = useState<{name: string, slug: string}[]>([]);
+  const [categories, setCategories] = useState<
+    { name: string; slug: string }[]
+  >([]);
   const [showCategoriesDropdown, setShowCategoriesDropdown] = useState(false);
   const navigate = useNavigate();
 
@@ -144,6 +147,13 @@ export const Header: React.FC<HeaderProps> = ({ onSearch }) => {
               <Star className="h-4 w-4" />
               <span>Đánh giá cao</span>
             </Link>
+            <Link
+              to="/history"
+              className="flex items-center space-x-1 text-gray-700 hover:text-primary-600 transition-colors font-medium"
+            >
+              <History className="h-4 w-4" />
+              <span>Lịch sử</span>
+            </Link>
 
             {/* Categories Dropdown */}
             <div className="relative">
@@ -242,6 +252,13 @@ export const Header: React.FC<HeaderProps> = ({ onSearch }) => {
             >
               <Star className="h-4 w-4" />
               <span>Đánh giá cao</span>
+            </Link>
+            <Link
+              to="/history"
+              className="flex items-center space-x-2 text-gray-700 hover:text-primary-600 transition-colors font-medium"
+            >
+              <History className="h-4 w-4" />
+              <span>Lịch sử</span>
             </Link>
 
             <div className="pt-3 border-t border-gray-200">

--- a/src/components/RecentHistorySection.tsx
+++ b/src/components/RecentHistorySection.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Clock, Calendar } from "lucide-react";
+import { api, ReadingHistoryItem } from "../services/api";
+
+const RecentHistorySection: React.FC = () => {
+  const [recentHistory, setRecentHistory] = useState<ReadingHistoryItem[]>([]);
+
+  useEffect(() => {
+    const history = api.readingHistory.getRecentReads();
+    setRecentHistory(history);
+  }, []);
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInHours = Math.floor(
+      (now.getTime() - date.getTime()) / (1000 * 60 * 60)
+    );
+
+    if (diffInHours < 1) return "Vừa xong";
+    if (diffInHours < 24) return `${diffInHours} giờ trước`;
+    if (diffInHours < 48) return "Hôm qua";
+
+    return date.toLocaleDateString("vi-VN");
+  };
+
+  if (recentHistory.length === 0) {
+    return null; // Don't show section if no history
+  }
+
+  return (
+    <section className="py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center space-x-3">
+            <Clock className="h-6 w-6 text-blue-600" />
+            <h2 className="text-2xl font-bold text-gray-900">Đọc gần đây</h2>
+          </div>
+          <Link
+            to="/history"
+            className="text-blue-600 hover:text-blue-700 font-medium text-sm transition-colors"
+          >
+            Xem tất cả →
+          </Link>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {recentHistory.slice(0, 8).map((item, index) => (
+            <div
+              key={`${item.mangaId}-${index}`}
+              className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-shadow"
+            >
+              {/* Manga Cover */}
+              <div className="relative">
+                <img
+                  src={item.coverUrl}
+                  alt={item.mangaTitle}
+                  className="w-full h-40 object-cover"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.src =
+                      "https://via.placeholder.com/300x400?text=No+Image";
+                  }}
+                />
+                <div className="absolute top-2 right-2 bg-black bg-opacity-70 text-white text-xs px-2 py-1 rounded">
+                  {item.readCount} lần
+                </div>
+              </div>
+
+              {/* Manga Info */}
+              <div className="p-3">
+                <Link
+                  to={`/manga/${item.mangaId}`}
+                  className="block hover:text-blue-600 transition-colors"
+                >
+                  <h3 className="font-semibold text-gray-900 mb-1 line-clamp-2 text-sm">
+                    {item.mangaTitle}
+                  </h3>
+                </Link>
+
+                <p className="text-xs text-gray-600 mb-2 line-clamp-1">
+                  {item.chapterTitle}
+                </p>
+
+                {/* Last Read Time */}
+                <div className="flex items-center justify-between text-xs text-gray-500">
+                  <div className="flex items-center space-x-1">
+                    <Calendar className="h-3 w-3" />
+                    <span>{formatDate(item.lastReadAt)}</span>
+                  </div>
+                </div>
+
+                {/* Continue Reading Button */}
+                <Link
+                  to={`/manga/${item.mangaId}/chapter/${item.chapterId}`}
+                  className="mt-2 w-full block text-center px-2 py-1.5 bg-blue-600 text-white text-xs rounded hover:bg-blue-700 transition-colors"
+                >
+                  Tiếp tục đọc
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default RecentHistorySection;

--- a/src/pages/AdminDashboardPage.tsx
+++ b/src/pages/AdminDashboardPage.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+const AdminDashboardPage: React.FC = () => {
+  return (
+    <div className="min-h-screen flex flex-col bg-gray-50">
+      <header className="bg-indigo-700 text-white p-4 text-2xl font-bold">
+        Dashboard Quản trị
+      </header>
+      <div className="flex flex-1">
+        {/* Sidebar */}
+        <aside className="w-64 bg-white border-r p-4 hidden md:block">
+          <nav>
+            <ul className="space-y-4">
+              <li>
+                <a href="#" className="text-indigo-700 font-semibold">
+                  Quản lý truyện
+                </a>
+              </li>
+              <li>
+                <a href="#" className="text-gray-700">
+                  Quản lý user
+                </a>
+              </li>
+              <li>
+                <a href="#" className="text-gray-700">
+                  Thống kê
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </aside>
+        {/* Main content */}
+        <main className="flex-1 p-8">
+          <h2 className="text-xl font-bold mb-4">Chào mừng Admin!</h2>
+          <p>
+            Đây là trang dashboard quản trị. Bạn có thể quản lý truyện, người
+            dùng và xem thống kê tại đây.
+          </p>
+          {/* Thêm các widget thống kê hoặc hướng dẫn sử dụng ở đây */}
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboardPage;

--- a/src/pages/ChapterReaderPage.tsx
+++ b/src/pages/ChapterReaderPage.tsx
@@ -1,18 +1,28 @@
-import React, { useState, useEffect } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
-import { ChevronLeft, ChevronRight, Home, List, Settings, Maximize, Minimize } from 'lucide-react';
-import { api } from '../services/api';
+import React, { useState, useEffect } from "react";
+import { useParams, Link } from "react-router-dom";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Home,
+  List,
+  Settings,
+  Maximize,
+  Minimize,
+} from "lucide-react";
+import { api } from "../services/api";
 
 export const ChapterReaderPage: React.FC = () => {
-  const { mangaId, chapterId } = useParams<{ mangaId: string; chapterId: string }>();
-  const navigate = useNavigate();
+  const { mangaId, chapterId } = useParams<{
+    mangaId: string;
+    chapterId: string;
+  }>();
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showControls, setShowControls] = useState(true);
   const [currentPage, setCurrentPage] = useState(0);
   const [pages, setPages] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
-  const [mangaTitle, setMangaTitle] = useState('');
-  const [chapterTitle, setChapterTitle] = useState('');
+  const [mangaTitle, setMangaTitle] = useState("");
+  const [chapterTitle, setChapterTitle] = useState("");
 
   useEffect(() => {
     const loadChapterData = async () => {
@@ -20,16 +30,22 @@ export const ChapterReaderPage: React.FC = () => {
 
       try {
         setLoading(true);
-        
+
         // Try to load chapter images from OTruyen API
         const chapterImages = await api.getChapterImages(mangaId, chapterId);
-        
+
         if (chapterImages.length > 0) {
           setPages(chapterImages);
         } else {
           // Fallback to mock pages
-          const mockPages = Array.from({ length: 20 }, (_, i) => 
-            `https://images.pexels.com/photos/${1000000 + i * 1000}/pexels-photo-${1000000 + i * 1000}.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop`
+          const mockPages = Array.from(
+            { length: 20 },
+            (_, i) =>
+              `https://images.pexels.com/photos/${
+                1000000 + i * 1000
+              }/pexels-photo-${
+                1000000 + i * 1000
+              }.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop`
           );
           setPages(mockPages);
         }
@@ -39,20 +55,52 @@ export const ChapterReaderPage: React.FC = () => {
         if (mangaData) {
           setMangaTitle(mangaData.title);
           setChapterTitle(`Chapter ${chapterId}`);
+
+          // Save to reading history
+          api.readingHistory.addToHistory(
+            mangaId,
+            mangaData.title,
+            chapterId,
+            `Chapter ${chapterId}`,
+            mangaData.coverUrl
+          );
         } else {
-          setMangaTitle('Sample Manga Title');
-          setChapterTitle('Chapter 1: The Beginning');
+          setMangaTitle("Sample Manga Title");
+          setChapterTitle("Chapter 1: The Beginning");
+
+          // Save to reading history with fallback data
+          api.readingHistory.addToHistory(
+            mangaId,
+            "Sample Manga Title",
+            chapterId,
+            "Chapter 1: The Beginning",
+            "https://images.pexels.com/photos/1029141/pexels-photo-1029141.jpeg?auto=compress&cs=tinysrgb&w=300&h=400&fit=crop"
+          );
         }
-        
       } catch (error) {
-        console.error('Error loading chapter:', error);
+        console.error("Error loading chapter:", error);
         // Use fallback data
-        const mockPages = Array.from({ length: 20 }, (_, i) => 
-          `https://images.pexels.com/photos/${1000000 + i * 1000}/pexels-photo-${1000000 + i * 1000}.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop`
+        const mockPages = Array.from(
+          { length: 20 },
+          (_, i) =>
+            `https://images.pexels.com/photos/${
+              1000000 + i * 1000
+            }/pexels-photo-${
+              1000000 + i * 1000
+            }.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop`
         );
         setPages(mockPages);
-        setMangaTitle('Sample Manga Title');
-        setChapterTitle('Chapter 1: The Beginning');
+        setMangaTitle("Sample Manga Title");
+        setChapterTitle("Chapter 1: The Beginning");
+
+        // Save to reading history with fallback data
+        api.readingHistory.addToHistory(
+          mangaId || "unknown",
+          "Sample Manga Title",
+          chapterId || "1",
+          "Chapter 1: The Beginning",
+          "https://images.pexels.com/photos/1029141/pexels-photo-1029141.jpeg?auto=compress&cs=tinysrgb&w=300&h=400&fit=crop"
+        );
       } finally {
         setLoading(false);
       }
@@ -63,19 +111,19 @@ export const ChapterReaderPage: React.FC = () => {
 
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
-      if (e.key === 'ArrowLeft' && currentPage > 0) {
+      if (e.key === "ArrowLeft" && currentPage > 0) {
         setCurrentPage(currentPage - 1);
-      } else if (e.key === 'ArrowRight' && currentPage < pages.length - 1) {
+      } else if (e.key === "ArrowRight" && currentPage < pages.length - 1) {
         setCurrentPage(currentPage + 1);
-      } else if (e.key === 'f' || e.key === 'F') {
+      } else if (e.key === "f" || e.key === "F") {
         toggleFullscreen();
-      } else if (e.key === 'h' || e.key === 'H') {
+      } else if (e.key === "h" || e.key === "H") {
         setShowControls(!showControls);
       }
     };
 
-    window.addEventListener('keydown', handleKeyPress);
-    return () => window.removeEventListener('keydown', handleKeyPress);
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
   }, [currentPage, pages.length, showControls]);
 
   const toggleFullscreen = () => {
@@ -112,9 +160,17 @@ export const ChapterReaderPage: React.FC = () => {
   }
 
   return (
-    <div className={`min-h-screen bg-black text-white ${isFullscreen ? 'fixed inset-0 z-50' : ''}`}>
+    <div
+      className={`min-h-screen bg-black text-white ${
+        isFullscreen ? "fixed inset-0 z-50" : ""
+      }`}
+    >
       {/* Header Controls */}
-      <div className={`sticky top-0 z-40 bg-black bg-opacity-90 backdrop-blur-sm transition-transform duration-300 ${showControls ? 'translate-y-0' : '-translate-y-full'}`}>
+      <div
+        className={`sticky top-0 z-40 bg-black bg-opacity-90 backdrop-blur-sm transition-transform duration-300 ${
+          showControls ? "translate-y-0" : "-translate-y-full"
+        }`}
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             <div className="flex items-center space-x-4">
@@ -140,7 +196,11 @@ export const ChapterReaderPage: React.FC = () => {
                 className="p-2 text-gray-400 hover:text-white transition-colors"
                 title="Toàn màn hình (F)"
               >
-                {isFullscreen ? <Minimize className="h-5 w-5" /> : <Maximize className="h-5 w-5" />}
+                {isFullscreen ? (
+                  <Minimize className="h-5 w-5" />
+                ) : (
+                  <Maximize className="h-5 w-5" />
+                )}
               </button>
               <button
                 onClick={() => setShowControls(!showControls)}
@@ -165,7 +225,8 @@ export const ChapterReaderPage: React.FC = () => {
                 className="w-full h-auto max-h-screen object-contain"
                 loading="lazy"
                 onError={(e) => {
-                  (e.target as HTMLImageElement).src = 'https://images.pexels.com/photos/1029141/pexels-photo-1029141.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop';
+                  (e.target as HTMLImageElement).src =
+                    "https://images.pexels.com/photos/1029141/pexels-photo-1029141.jpeg?auto=compress&cs=tinysrgb&w=800&h=1200&fit=crop";
                 }}
               />
             )}
@@ -175,29 +236,43 @@ export const ChapterReaderPage: React.FC = () => {
               onClick={prevPage}
               disabled={currentPage === 0}
               className={`absolute left-0 top-0 bottom-0 w-1/3 flex items-center justify-start pl-4 bg-transparent hover:bg-black hover:bg-opacity-20 transition-colors ${
-                currentPage === 0 ? 'cursor-not-allowed opacity-30' : ''
+                currentPage === 0 ? "cursor-not-allowed opacity-30" : ""
               }`}
               title="Trang trước (←)"
             >
-              <ChevronLeft className={`h-8 w-8 text-white opacity-0 group-hover:opacity-100 transition-opacity ${showControls ? 'opacity-60' : ''}`} />
+              <ChevronLeft
+                className={`h-8 w-8 text-white opacity-0 group-hover:opacity-100 transition-opacity ${
+                  showControls ? "opacity-60" : ""
+                }`}
+              />
             </button>
 
             <button
               onClick={nextPage}
               disabled={currentPage === pages.length - 1}
               className={`absolute right-0 top-0 bottom-0 w-1/3 flex items-center justify-end pr-4 bg-transparent hover:bg-black hover:bg-opacity-20 transition-colors ${
-                currentPage === pages.length - 1 ? 'cursor-not-allowed opacity-30' : ''
+                currentPage === pages.length - 1
+                  ? "cursor-not-allowed opacity-30"
+                  : ""
               }`}
               title="Trang sau (→)"
             >
-              <ChevronRight className={`h-8 w-8 text-white opacity-0 group-hover:opacity-100 transition-opacity ${showControls ? 'opacity-60' : ''}`} />
+              <ChevronRight
+                className={`h-8 w-8 text-white opacity-0 group-hover:opacity-100 transition-opacity ${
+                  showControls ? "opacity-60" : ""
+                }`}
+              />
             </button>
           </div>
         </div>
       </div>
 
       {/* Bottom Controls */}
-      <div className={`fixed bottom-0 left-0 right-0 z-40 bg-black bg-opacity-90 backdrop-blur-sm transition-transform duration-300 ${showControls ? 'translate-y-0' : 'translate-y-full'}`}>
+      <div
+        className={`fixed bottom-0 left-0 right-0 z-40 bg-black bg-opacity-90 backdrop-blur-sm transition-transform duration-300 ${
+          showControls ? "translate-y-0" : "translate-y-full"
+        }`}
+      >
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
@@ -205,7 +280,7 @@ export const ChapterReaderPage: React.FC = () => {
                 onClick={prevPage}
                 disabled={currentPage === 0}
                 className={`flex items-center space-x-2 px-4 py-2 bg-gray-800 rounded-lg hover:bg-gray-700 transition-colors ${
-                  currentPage === 0 ? 'cursor-not-allowed opacity-30' : ''
+                  currentPage === 0 ? "cursor-not-allowed opacity-30" : ""
                 }`}
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -216,7 +291,9 @@ export const ChapterReaderPage: React.FC = () => {
                 onClick={nextPage}
                 disabled={currentPage === pages.length - 1}
                 className={`flex items-center space-x-2 px-4 py-2 bg-gray-800 rounded-lg hover:bg-gray-700 transition-colors ${
-                  currentPage === pages.length - 1 ? 'cursor-not-allowed opacity-30' : ''
+                  currentPage === pages.length - 1
+                    ? "cursor-not-allowed opacity-30"
+                    : ""
                 }`}
               >
                 <span className="hidden sm:inline">Trang sau</span>
@@ -269,25 +346,6 @@ export const ChapterReaderPage: React.FC = () => {
           <p>H: Ẩn/hiện điều khiển</p>
         </div>
       )}
-
-      <style jsx>{`
-        .slider::-webkit-slider-thumb {
-          appearance: none;
-          height: 16px;
-          width: 16px;
-          border-radius: 50%;
-          background: #3b82f6;
-          cursor: pointer;
-        }
-        .slider::-moz-range-thumb {
-          height: 16px;
-          width: 16px;
-          border-radius: 50%;
-          background: #3b82f6;
-          cursor: pointer;
-          border: none;
-        }
-      `}</style>
     </div>
   );
 };

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
+import { Clock, Trash2, Eye, Calendar } from "lucide-react";
+import { api, ReadingHistoryItem } from "../services/api";
+
+const HistoryPage: React.FC = () => {
+  const [history, setHistory] = useState<ReadingHistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadHistory();
+  }, []);
+
+  const loadHistory = () => {
+    const historyData = api.readingHistory.getHistory();
+    setHistory(historyData);
+    setLoading(false);
+  };
+
+  const removeFromHistory = (mangaId: string) => {
+    api.readingHistory.removeFromHistory(mangaId);
+    loadHistory(); // Reload history
+  };
+
+  const clearAllHistory = () => {
+    if (window.confirm("Bạn có chắc muốn xóa toàn bộ lịch sử đọc truyện?")) {
+      api.readingHistory.clearHistory();
+      setHistory([]);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInHours = Math.floor(
+      (now.getTime() - date.getTime()) / (1000 * 60 * 60)
+    );
+
+    if (diffInHours < 1) return "Vừa xong";
+    if (diffInHours < 24) return `${diffInHours} giờ trước`;
+    if (diffInHours < 48) return "Hôm qua";
+
+    return date.toLocaleDateString("vi-VN");
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center space-x-3">
+            <Clock className="h-8 w-8 text-blue-600" />
+            <h1 className="text-3xl font-bold text-gray-900">
+              Lịch sử đọc truyện
+            </h1>
+          </div>
+
+          {history.length > 0 && (
+            <button
+              onClick={clearAllHistory}
+              className="flex items-center space-x-2 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+            >
+              <Trash2 className="h-4 w-4" />
+              <span>Xóa tất cả</span>
+            </button>
+          )}
+        </div>
+
+        {/* History List */}
+        {history.length === 0 ? (
+          <div className="text-center py-12">
+            <Clock className="h-16 w-16 text-gray-400 mx-auto mb-4" />
+            <h3 className="text-xl font-medium text-gray-900 mb-2">
+              Chưa có lịch sử đọc truyện
+            </h3>
+            <p className="text-gray-500 mb-6">
+              Bắt đầu đọc truyện để xem lịch sử ở đây
+            </p>
+            <Link
+              to="/"
+              className="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Khám phá truyện
+            </Link>
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {history.map((item, index) => (
+              <div
+                key={`${item.mangaId}-${index}`}
+                className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
+              >
+                {/* Manga Cover */}
+                <div className="relative">
+                  <img
+                    src={item.coverUrl}
+                    alt={item.mangaTitle}
+                    className="w-full h-48 object-cover"
+                    onError={(e) => {
+                      const target = e.target as HTMLImageElement;
+                      target.src =
+                        "https://via.placeholder.com/300x400?text=No+Image";
+                    }}
+                  />
+                  <div className="absolute top-2 right-2">
+                    <button
+                      onClick={() => removeFromHistory(item.mangaId)}
+                      className="p-1 bg-red-600 text-white rounded-full hover:bg-red-700 transition-colors"
+                      title="Xóa khỏi lịch sử"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Manga Info */}
+                <div className="p-4">
+                  <Link
+                    to={`/manga/${item.mangaId}`}
+                    className="block hover:text-blue-600 transition-colors"
+                  >
+                    <h3 className="font-semibold text-gray-900 mb-1 line-clamp-2">
+                      {item.mangaTitle}
+                    </h3>
+                  </Link>
+
+                  <p className="text-sm text-gray-600 mb-2 line-clamp-1">
+                    {item.chapterTitle}
+                  </p>
+
+                  {/* Stats */}
+                  <div className="flex items-center justify-between text-xs text-gray-500">
+                    <div className="flex items-center space-x-1">
+                      <Eye className="h-3 w-3" />
+                      <span>{item.readCount} lần</span>
+                    </div>
+                    <div className="flex items-center space-x-1">
+                      <Calendar className="h-3 w-3" />
+                      <span>{formatDate(item.lastReadAt)}</span>
+                    </div>
+                  </div>
+
+                  {/* Continue Reading Button */}
+                  <Link
+                    to={`/manga/${item.mangaId}/chapter/${item.chapterId}`}
+                    className="mt-3 w-full block text-center px-3 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 transition-colors"
+                  >
+                    Tiếp tục đọc
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default HistoryPage;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { FeaturedSection } from '../components/FeaturedSection';
-import { MangaGrid } from '../components/MangaGrid';
-import { api } from '../services/api';
-import { Manga } from '../types/manga';
+import React, { useState, useEffect } from "react";
+import { FeaturedSection } from "../components/FeaturedSection";
+import { MangaGrid } from "../components/MangaGrid";
+import RecentHistorySection from "../components/RecentHistorySection";
+import { api } from "../services/api";
+import { Manga } from "../types/manga";
 
 export const HomePage: React.FC = () => {
   const [featuredManga, setFeaturedManga] = useState<Manga[]>([]);
@@ -17,19 +18,18 @@ export const HomePage: React.FC = () => {
       try {
         setLoading(true);
         setError(null);
-        
+
         // Load home data from OTruyen API
         const homeData = await api.getHomeData();
-        
+
         setFeaturedManga(homeData.featured);
         setPopularManga(homeData.popular);
         setRecentManga(homeData.recent);
         setCompletedManga(homeData.completed);
-        
       } catch (error) {
-        console.error('Error loading home data:', error);
-        setError('Không thể tải dữ liệu. Vui lòng thử lại sau.');
-        
+        console.error("Error loading home data:", error);
+        setError("Không thể tải dữ liệu. Vui lòng thử lại sau.");
+
         // Fallback to mock data
         const mockData = api.getMockData();
         setFeaturedManga(mockData.featured);
@@ -48,10 +48,12 @@ export const HomePage: React.FC = () => {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">Có lỗi xảy ra</h1>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            Có lỗi xảy ra
+          </h1>
           <p className="text-gray-600 mb-4">{error}</p>
-          <button 
-            onClick={() => window.location.reload()} 
+          <button
+            onClick={() => window.location.reload()}
             className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
           >
             Thử lại
@@ -66,6 +68,9 @@ export const HomePage: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Featured Section */}
         <FeaturedSection featuredManga={featuredManga} />
+
+        {/* Recent History Section */}
+        <RecentHistorySection />
 
         {/* Popular Manga */}
         <MangaGrid

--- a/src/pages/TopRatedPage.tsx
+++ b/src/pages/TopRatedPage.tsx
@@ -25,7 +25,7 @@ export const TopRatedPage: React.FC = () => {
       const result = await api.getMangaList('truyen-full', page);
       
       // Sort by rating (mock ratings for now)
-      const sortedManga = result.manga.sort((a, b) => (b.rating || 0) - (a.rating || 0));
+      const sortedManga = result.manga.sort((a: Manga, b: Manga) => (b.rating || 0) - (a.rating || 0));
       
       setManga(sortedManga);
       setCurrentPage(result.currentPage);

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,4 @@
-const OTRUYEN_API = 'https://otruyenapi.com/v1/api';
+const OTRUYEN_API = "https://otruyenapi.com/v1/api";
 
 export interface OTruyenManga {
   _id: string;
@@ -20,6 +20,7 @@ export interface OTruyenManga {
     chapter_title: string;
     chapter_api_data: string;
   }>;
+  chapters?: OTruyenChapterData[];
   updatedAt: string;
   view: number;
 }
@@ -44,50 +45,112 @@ export interface OTruyenCategory {
   description: string;
 }
 
+export interface OTruyenChapterData {
+  filename: string;
+  chapter_name: string;
+  chapter_title: string;
+  updatedAt: string;
+}
+
+export interface OTruyenImageData {
+  image_page: number;
+  image_file: string;
+}
+
+export interface TransformedManga {
+  id: string;
+  title: string;
+  description: string;
+  coverUrl: string;
+  status: "ongoing" | "completed" | "hiatus" | "cancelled";
+  genres: string[];
+  author: string;
+  lastUpdated: string;
+  views: number;
+  rating: number;
+  latestChapter: string | null;
+  chapters?: TransformedChapter[];
+}
+
+export interface TransformedChapter {
+  id: string;
+  title: string;
+  number: number;
+  publishedAt: string;
+  views: number;
+  pages: string[];
+}
+
+export interface ReadingHistoryItem {
+  mangaId: string;
+  mangaTitle: string;
+  chapterId: string;
+  chapterTitle: string;
+  coverUrl: string;
+  lastReadAt: string;
+  readCount: number;
+}
+
+// Helper to ensure status is correct type
+function asMangaStatus(
+  status: string
+): "ongoing" | "completed" | "hiatus" | "cancelled" {
+  if (
+    status === "ongoing" ||
+    status === "completed" ||
+    status === "hiatus" ||
+    status === "cancelled"
+  )
+    return status;
+  return "ongoing";
+}
+
 export const api = {
   // Get home page data
   async getHomeData() {
     try {
       const response = await fetch(`${OTRUYEN_API}/home`);
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return {
           featured: data.data.items.map(this.transformManga),
           popular: data.data.items.slice(0, 12).map(this.transformManga),
           recent: data.data.items.slice(12, 24).map(this.transformManga),
-          completed: data.data.items.filter((item: OTruyenManga) => 
-            item.status === 'completed'
-          ).map(this.transformManga)
+          completed: data.data.items
+            .filter((item: OTruyenManga) => item.status === "completed")
+            .map(this.transformManga),
         };
       }
-      
+
       // Fallback to mock data if API fails
       return this.getMockData();
     } catch (error) {
-      console.error('Error fetching home data:', error);
+      console.error("Error fetching home data:", error);
       return this.getMockData();
     }
   },
 
   // Get manga list by type
-  async getMangaList(type: string = 'truyen-moi', page: number = 1) {
+  async getMangaList(type: string = "truyen-moi", page: number = 1) {
     try {
-      const response = await fetch(`${OTRUYEN_API}/danh-sach/${type}?page=${page}`);
+      const response = await fetch(
+        `${OTRUYEN_API}/danh-sach/${type}?page=${page}`
+      );
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return {
           manga: data.data.items.map(this.transformManga),
           total: data.data.params.pagination.totalItems,
           currentPage: data.data.params.pagination.currentPage,
-          totalPages: data.data.params.pagination.totalPages
+          totalPages: data.data.params.pagination.totalPages,
         };
       }
-      
+
       return { manga: [], total: 0, currentPage: 1, totalPages: 1 };
     } catch (error) {
-      console.error('Error fetching manga list:', error);
+      console.error("Error fetching manga list:", error);
       return { manga: [], total: 0, currentPage: 1, totalPages: 1 };
     }
   },
@@ -97,14 +160,14 @@ export const api = {
     try {
       const response = await fetch(`${OTRUYEN_API}/the-loai`);
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return data.data.items;
       }
-      
+
       return [];
     } catch (error) {
-      console.error('Error fetching categories:', error);
+      console.error("Error fetching categories:", error);
       return [];
     }
   },
@@ -112,23 +175,37 @@ export const api = {
   // Get manga by category
   async getMangaByCategory(slug: string, page: number = 1) {
     try {
-      const response = await fetch(`${OTRUYEN_API}/the-loai/${slug}?page=${page}`);
+      const response = await fetch(
+        `${OTRUYEN_API}/the-loai/${slug}?page=${page}`
+      );
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return {
           manga: data.data.items.map(this.transformManga),
           total: data.data.params.pagination.totalItems,
           currentPage: data.data.params.pagination.currentPage,
           totalPages: data.data.params.pagination.totalPages,
-          categoryName: data.data.titlePage
+          categoryName: data.data.titlePage,
         };
       }
-      
-      return { manga: [], total: 0, currentPage: 1, totalPages: 1, categoryName: '' };
+
+      return {
+        manga: [],
+        total: 0,
+        currentPage: 1,
+        totalPages: 1,
+        categoryName: "",
+      };
     } catch (error) {
-      console.error('Error fetching manga by category:', error);
-      return { manga: [], total: 0, currentPage: 1, totalPages: 1, categoryName: '' };
+      console.error("Error fetching manga by category:", error);
+      return {
+        manga: [],
+        total: 0,
+        currentPage: 1,
+        totalPages: 1,
+        categoryName: "",
+      };
     }
   },
 
@@ -137,14 +214,14 @@ export const api = {
     try {
       const response = await fetch(`${OTRUYEN_API}/truyen-tranh/${slug}`);
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return this.transformMangaDetail(data.data.item);
       }
-      
+
       return null;
     } catch (error) {
-      console.error('Error fetching manga details:', error);
+      console.error("Error fetching manga details:", error);
       return null;
     }
   },
@@ -152,130 +229,275 @@ export const api = {
   // Search manga
   async searchManga(query: string, page: number = 1) {
     try {
-      const response = await fetch(`${OTRUYEN_API}/tim-kiem?keyword=${encodeURIComponent(query)}&page=${page}`);
+      const response = await fetch(
+        `${OTRUYEN_API}/tim-kiem?keyword=${encodeURIComponent(
+          query
+        )}&page=${page}`
+      );
       const data = await response.json();
-      
-      if (data.status === 'success') {
+
+      if (data.status === "success") {
         return {
           manga: data.data.items.map(this.transformManga),
           total: data.data.params.pagination.totalItems,
           currentPage: data.data.params.pagination.currentPage,
-          totalPages: data.data.params.pagination.totalPages
+          totalPages: data.data.params.pagination.totalPages,
         };
       }
-      
+
       return { manga: [], total: 0, currentPage: 1, totalPages: 1 };
     } catch (error) {
-      console.error('Error searching manga:', error);
+      console.error("Error searching manga:", error);
       return { manga: [], total: 0, currentPage: 1, totalPages: 1 };
     }
   },
 
   // Transform OTruyen manga data to our format
-  transformManga: (mangaData: OTruyenManga): any => {
+  transformManga: (mangaData: OTruyenManga): TransformedManga => {
     return {
       id: mangaData.slug,
       title: mangaData.name,
-      description: mangaData.content?.replace(/<[^>]*>/g, '') || '', // Remove HTML tags
+      description: mangaData.content?.replace(/<[^>]*>/g, "") || "", // Remove HTML tags
       coverUrl: `https://img.otruyenapi.com/uploads/comics/${mangaData.thumb_url}`,
       status: api.mapStatus(mangaData.status),
-      genres: mangaData.category?.map(cat => cat.name) || [],
-      author: mangaData.author?.join(', ') || 'Unknown Author',
+      genres: mangaData.category?.map((cat) => cat.name) || [],
+      author: mangaData.author?.join(", ") || "Unknown Author",
       lastUpdated: mangaData.updatedAt,
       views: mangaData.view || 0,
       rating: Math.round((Math.random() * 2 + 8) * 10) / 10, // Mock rating since API doesn't provide it
-      latestChapter: mangaData.chaptersLatest?.[0]?.chapter_name || null
+      latestChapter: mangaData.chaptersLatest?.[0]?.chapter_name || null,
     };
   },
 
   // Transform detailed manga data
-  transformMangaDetail: (mangaData: any): any => {
+  transformMangaDetail: (mangaData: OTruyenManga): TransformedManga => {
     const transformed = api.transformManga(mangaData);
-    
+
     // Add chapters if available
     if (mangaData.chapters && mangaData.chapters.length > 0) {
-      transformed.chapters = mangaData.chapters.map((chapter: any) => ({
-        id: chapter.filename,
-        title: chapter.chapter_title || `Chapter ${chapter.chapter_name}`,
-        number: parseFloat(chapter.chapter_name) || 0,
-        publishedAt: chapter.updatedAt || new Date().toISOString(),
-        views: Math.floor(Math.random() * 10000) + 100, // Mock views
-        pages: []
-      })).reverse(); // Reverse to show latest first
+      transformed.chapters = mangaData.chapters
+        .map((chapter: OTruyenChapterData) => ({
+          id: chapter.filename,
+          title: chapter.chapter_title || `Chapter ${chapter.chapter_name}`,
+          number: parseFloat(chapter.chapter_name) || 0,
+          publishedAt: chapter.updatedAt || new Date().toISOString(),
+          views: Math.floor(Math.random() * 10000) + 100, // Mock views
+          pages: [],
+        }))
+        .reverse(); // Reverse to show latest first
     }
-    
+
     return transformed;
   },
 
   // Map OTruyen status to our format
-  mapStatus: (status: string): 'ongoing' | 'completed' | 'hiatus' | 'cancelled' => {
+  mapStatus: (
+    status: string
+  ): "ongoing" | "completed" | "hiatus" | "cancelled" => {
     switch (status?.toLowerCase()) {
-      case 'completed':
-      case 'hoàn thành':
-        return 'completed';
-      case 'ongoing':
-      case 'đang tiến hành':
-        return 'ongoing';
-      case 'hiatus':
-      case 'tạm ngưng':
-        return 'hiatus';
+      case "completed":
+      case "hoàn thành":
+        return "completed";
+      case "ongoing":
+      case "đang tiến hành":
+        return "ongoing";
+      case "hiatus":
+      case "tạm ngưng":
+        return "hiatus";
       default:
-        return 'ongoing';
+        return "ongoing";
     }
   },
 
   // Get chapter images
   async getChapterImages(slug: string, chapterFilename: string) {
     try {
-      const response = await fetch(`${OTRUYEN_API}/truyen-tranh/${slug}/${chapterFilename}`);
+      const response = await fetch(
+        `${OTRUYEN_API}/truyen-tranh/${slug}/${chapterFilename}`
+      );
       const data = await response.json();
-      
-      if (data.status === 'success' && data.data.item.chapter_image) {
+
+      if (data.status === "success" && data.data.item.chapter_image) {
         return data.data.item.chapter_image
-          .sort((a: any, b: any) => a.image_page - b.image_page)
-          .map((img: any) => `https://img.otruyenapi.com/uploads/comics/${data.data.item.chapter_path}/${img.image_file}`);
+          .sort(
+            (a: OTruyenImageData, b: OTruyenImageData) =>
+              a.image_page - b.image_page
+          )
+          .map(
+            (img: OTruyenImageData) =>
+              `https://img.otruyenapi.com/uploads/comics/${data.data.item.chapter_path}/${img.image_file}`
+          );
       }
-      
+
       return [];
     } catch (error) {
-      console.error('Error fetching chapter images:', error);
+      console.error("Error fetching chapter images:", error);
       return [];
     }
   },
 
   // Fallback mock data
   getMockData() {
-    const mockManga = Array.from({ length: 24 }, (_, i) => ({
-      id: `manga-${i + 1}`,
-      title: [
-        'Attack on Titan', 'One Piece', 'Naruto', 'Dragon Ball', 'Bleach', 'Death Note',
-        'My Hero Academia', 'Demon Slayer', 'Tokyo Ghoul', 'Hunter x Hunter',
-        'Fullmetal Alchemist', 'Jujutsu Kaisen', 'Chainsaw Man', 'Spy x Family',
-        'Mob Psycho 100', 'One Punch Man', 'Black Clover', 'Fire Force',
-        'Dr. Stone', 'Promised Neverland', 'Kaguya-sama', 'Violet Evergarden',
-        'Your Name', 'Weathering With You'
-      ][i],
-      description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      coverUrl: `https://images.pexels.com/photos/${1000000 + i * 100}/pexels-photo-${1000000 + i * 100}.jpeg?auto=compress&cs=tinysrgb&w=300&h=400&fit=crop`,
-      status: ['ongoing', 'completed', 'hiatus'][Math.floor(Math.random() * 3)],
-      genres: ['Action', 'Adventure', 'Romance', 'Comedy', 'Drama', 'Fantasy'].slice(0, Math.floor(Math.random() * 4) + 2),
-      author: 'Author Name',
-      year: 2020 + Math.floor(Math.random() * 4),
-      rating: Math.round((Math.random() * 2 + 8) * 10) / 10,
-      lastUpdated: new Date().toISOString(),
-      views: Math.floor(Math.random() * 100000) + 1000,
-    }));
+    const mockManga = Array.from({ length: 24 }, (_, i) => {
+      const statusArr = ["ongoing", "completed", "hiatus"] as const;
+      const status = asMangaStatus(statusArr[Math.floor(Math.random() * 3)]);
+      return {
+        id: `manga-${i + 1}`,
+        title: [
+          "Attack on Titan",
+          "One Piece",
+          "Naruto",
+          "Dragon Ball",
+          "Bleach",
+          "Death Note",
+          "My Hero Academia",
+          "Demon Slayer",
+          "Tokyo Ghoul",
+          "Hunter x Hunter",
+          "Fullmetal Alchemist",
+          "Jujutsu Kaisen",
+          "Chainsaw Man",
+          "Spy x Family",
+          "Mob Psycho 100",
+          "One Punch Man",
+          "Black Clover",
+          "Fire Force",
+          "Dr. Stone",
+          "Promised Neverland",
+          "Kaguya-sama",
+          "Violet Evergarden",
+          "Your Name",
+          "Weathering With You",
+        ][i],
+        description:
+          "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        coverUrl: `https://images.pexels.com/photos/${
+          1000000 + i * 100
+        }/pexels-photo-${
+          1000000 + i * 100
+        }.jpeg?auto=compress&cs=tinysrgb&w=300&h=400&fit=crop`,
+        status,
+        genres: [
+          "Action",
+          "Adventure",
+          "Romance",
+          "Comedy",
+          "Drama",
+          "Fantasy",
+        ].slice(0, Math.floor(Math.random() * 4) + 2),
+        author: "Author Name",
+        year: 2020 + Math.floor(Math.random() * 4),
+        rating: Math.round((Math.random() * 2 + 8) * 10) / 10,
+        lastUpdated: new Date().toISOString(),
+        views: Math.floor(Math.random() * 100000) + 1000,
+      };
+    });
 
     return {
       featured: mockManga.slice(0, 4),
       popular: mockManga.slice(0, 12),
       recent: mockManga.slice(12, 24),
-      completed: mockManga.filter(m => m.status === 'completed').slice(0, 12)
+      completed: mockManga.filter((m) => m.status === "completed").slice(0, 12),
     };
   },
 
   // Legacy method for backward compatibility
   getMockManga() {
     return this.getMockData().popular;
-  }
+  },
+
+  // Reading History Management (Frontend only)
+  readingHistory: {
+    // Get reading history from localStorage
+    getHistory(): ReadingHistoryItem[] {
+      try {
+        const history = localStorage.getItem("reading_history");
+        return history ? JSON.parse(history) : [];
+      } catch (error) {
+        console.error("Error reading history from localStorage:", error);
+        return [];
+      }
+    },
+
+    // Add or update reading history
+    addToHistory(
+      mangaId: string,
+      mangaTitle: string,
+      chapterId: string,
+      chapterTitle: string,
+      coverUrl: string
+    ): void {
+      try {
+        const history = this.getHistory();
+        const existingIndex = history.findIndex(
+          (item) => item.mangaId === mangaId
+        );
+
+        const newItem: ReadingHistoryItem = {
+          mangaId,
+          mangaTitle,
+          chapterId,
+          chapterTitle,
+          coverUrl,
+          lastReadAt: new Date().toISOString(),
+          readCount: 1,
+        };
+
+        if (existingIndex !== -1) {
+          // Update existing item
+          newItem.readCount = history[existingIndex].readCount + 1;
+          history.splice(existingIndex, 1);
+        }
+
+        // Add to beginning of array (most recent first)
+        history.unshift(newItem);
+
+        // Keep only last 50 items
+        if (history.length > 50) {
+          history.splice(50);
+        }
+
+        localStorage.setItem("reading_history", JSON.stringify(history));
+      } catch (error) {
+        console.error("Error saving reading history:", error);
+      }
+    },
+
+    // Remove item from history
+    removeFromHistory(mangaId: string): void {
+      try {
+        const history = this.getHistory();
+        const filteredHistory = history.filter(
+          (item) => item.mangaId !== mangaId
+        );
+        localStorage.setItem(
+          "reading_history",
+          JSON.stringify(filteredHistory)
+        );
+      } catch (error) {
+        console.error("Error removing from reading history:", error);
+      }
+    },
+
+    // Clear all history
+    clearHistory(): void {
+      try {
+        localStorage.removeItem("reading_history");
+      } catch (error) {
+        console.error("Error clearing reading history:", error);
+      }
+    },
+
+    // Get reading progress for a specific manga
+    getReadingProgress(mangaId: string): ReadingHistoryItem | null {
+      const history = this.getHistory();
+      return history.find((item) => item.mangaId === mangaId) || null;
+    },
+
+    // Get recent reads (last 10 items)
+    getRecentReads(): ReadingHistoryItem[] {
+      const history = this.getHistory();
+      return history.slice(0, 10);
+    },
+  },
 };


### PR DESCRIPTION
## Mô tả
- Thêm chức năng lưu và hiển thị lịch sử đọc truyện cho người dùng (localStorage, frontend-only).
- Trang /history: Xem, xóa từng truyện hoặc xóa toàn bộ lịch sử.
- Section "Đọc gần đây" trên trang chủ.
- Tự động lưu lịch sử khi đọc chapter.
- Responsive đầy đủ, UI/UX thân thiện.

## Checklist
- [x] Đọc truyện/chapter bất kỳ, kiểm tra lịch sử xuất hiện ở trang Lịch sử.
- [x] Xóa từng truyện hoặc xóa toàn bộ lịch sử.
- [x] Nút "Tiếp tục đọc" hoạt động đúng.
- [x] Lịch sử hiển thị trên trang chủ (section Đọc gần đây).
- [x] Không còn lỗi typescript/linter.
- [x] Đã test responsive trên mobile/desktop.

 Anh/chị vui lòng review giúp em. Nếu có bug/blocker, em sẽ fix ngay!